### PR TITLE
fix: parse Facebook OAuth relationships

### DIFF
--- a/src/models/stubs_identification_link.rs
+++ b/src/models/stubs_identification_link.rs
@@ -31,6 +31,8 @@ pub enum Type {
     OauthApple,
     #[serde(rename = "oauth_google")]
     OauthGoogle,
+    #[serde(rename = "oauth_facebook")]
+    OauthFacebook,
     #[serde(rename = "oauth_mock")]
     OauthMock,
     #[serde(rename = "oauth_custom_mock")]

--- a/src/models/stubs_verification_from_oauth.rs
+++ b/src/models/stubs_verification_from_oauth.rs
@@ -79,6 +79,8 @@ pub enum Strategy {
     FromOauthApple,
     #[serde(rename = "from_oauth_google")]
     FromOauthGoogle,
+    #[serde(rename = "from_oauth_facebook")]
+    FromOauthFacebook,
     #[serde(rename = "from_oauth_mock")]
     FromOauthMock,
     #[serde(rename = "from_oauth_custom_mock")]

--- a/tests/clerk_tests.rs
+++ b/tests/clerk_tests.rs
@@ -971,3 +971,34 @@ async fn test_parse_client() {
     // this is just smoke test to be able to parse real client data
     let _client: clerk_fapi_rs::models::ClientClient = serde_json::from_value(value1).unwrap();
 }
+
+/// Protects Facebook-linked users from losing the live Clerk client when its OAuth relationship is
+/// deserialized during native startup.
+#[test]
+fn test_parse_facebook_linked_client() {
+    let mut value = logged_in_client();
+    let verification_value = {
+        let email = &mut value["sessions"][0]["user"]["email_addresses"][0];
+        email["verification"]["strategy"] = serde_json::json!("from_oauth_facebook");
+        email["linked_to"][0]["type"] = serde_json::json!("oauth_facebook");
+        email["verification"].clone()
+    };
+    let external_account = &mut value["sessions"][0]["user"]["external_accounts"][0];
+    external_account["object"] = serde_json::json!("facebook_account");
+    external_account["provider"] = serde_json::json!("facebook");
+    external_account["verification"]["strategy"] = serde_json::json!("from_oauth_facebook");
+
+    let verification: clerk_fapi_rs::models::StubsVerificationFromOauth =
+        serde_json::from_value(verification_value).unwrap();
+    assert_eq!(
+        verification.strategy,
+        clerk_fapi_rs::models::stubs_verification_from_oauth::Strategy::FromOauthFacebook
+    );
+
+    let client: clerk_fapi_rs::models::ClientClient = serde_json::from_value(value).unwrap();
+    let user = client.sessions[0].user.as_ref().unwrap();
+    assert_eq!(
+        user.email_addresses[0].linked_to[0].r#type,
+        clerk_fapi_rs::models::stubs_identification_link::Type::OauthFacebook
+    );
+}


### PR DESCRIPTION
## Summary

- accept `oauth_facebook` in identification links
- accept `from_oauth_facebook` in OAuth verification sources
- cover a complete Facebook-linked Clerk client response with a regression test

## Why

Clerk includes these values when a user has a Facebook OAuth relationship. The generated enums do
not currently contain them, so deserializing the complete client response fails at the first
Facebook identification link instead of returning the signed-in client.

Both values are part of the same response boundary: `oauth_facebook` appears in the email
identification's `linked_to` collection, while `from_oauth_facebook` can appear as the email
verification strategy.

## Validation

- `cargo fmt --check`
- focused Facebook-linked complete-client regression
- complete suite: 13 unit tests, 8 integration tests, and 1 doc test

On Rust 1.96.0, the repository's all-features Clippy command also reports existing
`derivable_impls` diagnostics across generated model files. This patch does not add or change any of
those diagnostics.
